### PR TITLE
Disabled f_mass_storage write cache

### DIFF
--- a/kernel/drivers/usb/gadget/f_mass_storage.c
+++ b/kernel/drivers/usb/gadget/f_mass_storage.c
@@ -1424,7 +1424,7 @@ static int do_mode_sense(struct fsg_common *common, struct fsg_buffhd *bh)
 		memset(buf+2, 0, 10);	/* None of the fields are changeable */
 
 		if (!changeable_values) {
-			buf[2] = 0x04;	/* Write cache enable, */
+			buf[2] = 0x00;	/* Write cache disabled, */
 					/* Read cache not disabled */
 					/* No cache retention priorities */
 			put_unaligned_be16(0xffff, &buf[4]);


### PR DESCRIPTION
As part of mode sense CBW command, communicate to the
host that write cache support is enabled and due to this
during the write commnd, the host is asking for FUA and
because of this write performance is degrading. Hence during
mode sense command, intimate the host that write cache is not
supported.
