### PR TITLE
Fix CRT-OFF effect by cocafe

### DIFF
--- a/kernel/kernel/power/fbearlysuspend.c
+++ b/kernel/kernel/power/fbearlysuspend.c
@@ -17,6 +17,15 @@
 #include <linux/module.h>
 #include <linux/wait.h>
 
+#include <linux/delay.h>
+#include <linux/moduleparam.h>
+
+bool fbdelay = false;
+unsigned int fbdelay_ms = 350;
+
+module_param(fbdelay, bool, 0644);
+module_param(fbdelay_ms, uint, 0644);
+
 #include "power.h"
 
 static wait_queue_head_t fb_state_wq;
@@ -32,6 +41,10 @@ static void stop_drawing_early_suspend(struct early_suspend *h)
 {
 	int ret;
 	unsigned long irq_flags;
+	
+	if (fbdelay) {
+    	msleep(fbdelay_ms);
+	}
 
 	spin_lock_irqsave(&fb_state_lock, irq_flags);
 	fb_state = FB_STATE_REQUEST_STOP_DRAWING;


### PR DESCRIPTION
Fix taken from cocafe's repo to enable fbearlysuspend delay (350ms)
